### PR TITLE
test/regnet.py: Remove call to non-existent bitcoin rpc stop() method

### DIFF
--- a/test/regnet.py
+++ b/test/regnet.py
@@ -99,7 +99,6 @@ class BitcoinNode(object):
             except ProcessLookupError:
                 pass
         else:
-            self.proxy.stop()
             self.process.wait()
         if cleanup:
             self.cleanup()


### PR DESCRIPTION
In stop method of class BitcoinNode there is a line "proxy.stop()" which
fails when executed since the class bitcoin.rpc.Proxy has no stop()
method. It seems the rpc connection is closed on object deletion and
therefore this call isn't needed.
